### PR TITLE
Add null check for streamKey in receiveCommand

### DIFF
--- a/android/src/oldarch/LiveStreamViewManagerSpec.kt
+++ b/android/src/oldarch/LiveStreamViewManagerSpec.kt
@@ -21,7 +21,7 @@ abstract class LiveStreamViewManagerSpec<T : View> : SimpleViewManager<T>() {
     when (commandId) {
       ViewProps.Commands.START_STREAMING.action -> {
         val requestId = args?.getInt(0) ?: return
-        val streamKey = args.getString(1)
+        val streamKey = args.getString(1) ?: return
         val url = args.getString(2)
         startStreaming(root, requestId, streamKey, url)
       }


### PR DESCRIPTION
``` shell
> Task :api.video_react-native-livestream:compileDebugKotlin FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.13/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
256 actionable tasks: 248 executed, 8 up-to-date

info 💡 Tip: Make sure that you have set up your development environment correctly, by running npx react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor

node_modules/@api.video/react-native-livestream/android/src/oldarch/LiveStreamViewManagerSpec.kt:26:41 Argument type mismatch: actual type is 'kotlin.String?', but 'kotlin.String' was expected.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':api.video_react-native-livestream:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 17s
error Failed to install the app. Command failed with exit code 1: ./gradlew app:installDebug -PreactNativeDevServerPort=8081
node_modules/@api.video/react-native-livestream/android/src/oldarch/LiveStreamViewManagerSpec.kt:26:41 Argument type mismatch: actual type is 'kotlin.String?', but 'kotlin.String' was expected. FAILURE: Build failed with an exception. * What went wrong:
Execution failed for task ':api.video_react-native-livestream:compileDebugKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction > Compilation error. See log for more details * Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org. BUILD FAILED in 17s.
```